### PR TITLE
feat(logging-utils): Google log message class and structured formatter

### DIFF
--- a/google-logging-utils/.rubocop.yml
+++ b/google-logging-utils/.rubocop.yml
@@ -8,3 +8,12 @@ AllCops:
 Naming/FileName:
   Exclude:
     - "lib/google-logging-utils.rb"
+
+Metrics/ClassLength:
+  Max: 200
+Metrics/AbcSize:
+  Max: 40
+Metrics/CyclomaticComplexity:
+  Max: 15
+Metrics/PerceivedComplexity:
+  Max: 15

--- a/google-logging-utils/lib/google/logging/message.rb
+++ b/google-logging-utils/lib/google/logging/message.rb
@@ -1,0 +1,317 @@
+# frozen_string_literal: true
+
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "json"
+require "google/logging/source_location"
+
+module Google
+  module Logging
+    ##
+    # A log message that can be formatted either as a normal text log entry or
+    # as a structured log entry suitable for Google Cloud Logging.
+    #
+    # A log message has a "body" which consists of either a string message, a
+    # JSON object (i.e. a Hash whose values are typically strings or numbers
+    # but could be nested arrays and hashes), or both. It also includes several
+    # additional optional fields used by the Google Cloud Logging backend.
+    #
+    # Most log formatters will render the message body as a string and ignore
+    # the other attributes. The {StructuredFormatter}, however, will format the
+    # full message data in the JSON format understood by the Google logging
+    # agent.
+    #
+    class Message
+      ##
+      # Create a log message from an input object, which can be any of:
+      #
+      # * An existing Message object.
+      # * A Hash. Symbol keys are used as keyword arguments to the
+      #   {Message#initialize} constructor. String keys are treated as fields
+      #   in the JSON payload.
+      # * Any other object is converted to a string with `to_s` and used as a
+      #   simple text payload.
+      #
+      # @param input [Object] A log message input object.
+      # @return [Message]
+      #
+      def self.from input
+        case input
+        when Hash
+          kwargs = {}
+          fields = nil
+          input.each do |k, v|
+            if k.is_a? Symbol
+              kwargs[k] = v
+            else
+              (fields ||= {})[k.to_s] = v
+            end
+          end
+          if kwargs[:fields] && fields
+            kwargs[:fields].merge! fields
+          else
+            kwargs[:fields] ||= fields
+          end
+          new(**kwargs)
+        when Message
+          input
+        else
+          new message: input.to_s
+        end
+      end
+
+      ##
+      # Low-level constructor for a logging message.
+      # All arguments are optional, with the exception that at least one of
+      # `:message` and `:fields` must be provided.
+      #
+      # @param message [String] The main log message as a string.
+      # @param fields [Hash{String=>Object}] The log message as a set of
+      #     key-value pairs representing a JSON object.
+      # @param timestamp [Time,Numeric,:now] The timestamp for the log entry.
+      #     Can be provided as a Time object, a Numeric indicating the seconds
+      #     since epoch, or `:now` to use the current time. Optional.
+      # @param source_location [SourceLocation,Hash,:caller,nil] The source
+      #     location for the log entry. Can be provided as a {SourceLocation}
+      #     object, a Hash containing exactly the keys `:file`, `:line`, and
+      #     `:function`, or `:caller` to use the location of the caller.
+      #     Optional.
+      # @param insert_id [String] A unique ID for this log entry that could be
+      #     used on the backend to dedup messages. Optional.
+      # @param trace [String] A Google Cloud Trace resource name. Optional.
+      # @param span_id [String] The trace span containing this entry. Optional.
+      # @param trace_sampled [boolean] Whether this trace is sampled. Optional.
+      # @param labels [Hash{String=>String}] Optional metadata.
+      #
+      def initialize message: nil,
+                     fields: nil,
+                     timestamp: nil,
+                     source_location: nil,
+                     insert_id: nil,
+                     trace: nil,
+                     span_id: nil,
+                     trace_sampled: nil,
+                     labels: nil
+        @fields = interpret_fields fields
+        @message, @full_message = interpret_message message, @fields
+        @timestamp = interpret_timestamp timestamp
+        @source_location = interpret_source_location source_location
+        @insert_id = interpret_string insert_id
+        @trace = interpret_string trace
+        @span_id = interpret_string span_id
+        @trace_sampled = interpret_boolean trace_sampled
+        @labels = interpret_labels labels
+      end
+
+      ##
+      # @return [String] The message as a string. This is always present as a
+      #     nonempty string, and can be reliably used as the "display" of this
+      #     log entry in a list of entries.
+      #
+      attr_reader :message
+      alias to_s message
+
+      ##
+      # @return [String] A full string representation of the message and fields
+      #     as rendered in the standard logger formatter.
+      #
+      attr_reader :full_message
+      alias inspect full_message
+
+      ##
+      # @return [Hash{String=>Object},nil] The log message as a set of
+      #     key-value pairs, or nil if not present.
+      #
+      attr_reader :fields
+
+      ##
+      # @return [Time,nil] The timestamp for the log entry, or nil if not
+      #     present.
+      #
+      attr_reader :timestamp
+
+      ##
+      # @return [SourceLocation,nil] The source location for the log entry, or
+      #     nil if not present.
+      #
+      attr_reader :source_location
+
+      ##
+      # @return [String,nil] The unique ID for this log entry that could be
+      #     used on the backend to dedup messages, or nil if not present.
+      #
+      attr_reader :insert_id
+
+      ##
+      # @return [String,nil] The Google Cloud Trace resource name, or nil if
+      #     not present.
+      #
+      attr_reader :trace
+
+      ##
+      # @return [String,nil] The trace span containing this entry, or nil if
+      #     not present.
+      #
+      attr_reader :span_id
+
+      ##
+      # @return [true,false,nil] Whether this trace is sampled, or nil if not
+      #     present or known.
+      #
+      attr_reader :trace_sampled
+      alias trace_sampled? trace_sampled
+
+      ##
+      # @return [Hash{String=>String},nil] Metadata, or nil if not present.
+      #
+      attr_reader :labels
+
+      ##
+      # @return [Hash] A hash of kwargs that can be passed to the constructor
+      #     to clone this message.
+      #
+      def to_h
+        {
+          message: @message,
+          fields: @fields.dup,
+          timestamp: @timestamp,
+          source_location: @source_location,
+          insert_id: @insert_id,
+          trace: @trace,
+          span_id: @span_id,
+          trace_sampled: @trace_sampled,
+          labels: @labels.dup
+        }
+      end
+
+      # @private
+      def == other
+        return false unless other.is_a? Message
+        message == other.message &&
+          fields == other.fields &&
+          timestamp == other.timestamp &&
+          source_location == other.source_location &&
+          insert_id == other.insert_id &&
+          trace == other.trace &&
+          span_id == other.span_id &&
+          trace_sampled? == other.trace_sampled? &&
+          labels == other.labels
+      end
+      alias eql? ==
+
+      # @private
+      def hash
+        [message, fields, timestamp, source_location, insert_id, trace, span_id, trace_sampled, labels].hash
+      end
+
+      private
+
+      # @private
+      DISALLOWED_FIELDS = [
+        "severity",
+        "message",
+        "log",
+        "httpRequest",
+        "timestamp"
+      ].freeze
+
+      def interpret_fields fields
+        return nil if fields.nil?
+        fields = normalize_json fields
+        fields.each_key do |key|
+          if DISALLOWED_FIELDS.include?(key) || key.start_with?("logging.googleapis.com/")
+            raise ArgumentError, "Field key not allowed: #{key}"
+          end
+        end
+        fields
+      end
+
+      def normalize_json input
+        case input
+        when Hash
+          input.to_h { |k, v| [k.to_s, normalize_json(v)] }
+        when Array
+          input.map { |v| normalize_json v }
+        when Integer, Float, nil, true, false
+          input
+        when Rational
+          if input.denominator == 1
+            input.numerator
+          else
+            input.to_f
+          end
+        else
+          input.to_s
+        end
+      end
+
+      def interpret_message message, fields
+        if message
+          message = message.to_s
+          full_message = fields ? "#{message} -- #{JSON.generate fields}" : message
+          [message, full_message]
+        else
+          fields_json = JSON.generate fields
+          [fields_json, fields_json]
+        end
+      end
+
+      def interpret_timestamp timestamp
+        case timestamp
+        when Time
+          timestamp
+        when Numeric
+          Time.at timestamp
+        when :now
+          Time.now.utc
+        end
+      end
+
+      def interpret_source_location source_location
+        case source_location
+        when SourceLocation
+          source_location
+        when Hash
+          SourceLocation.new(**source_location)
+        when :caller
+          SourceLocation.for_caller omit_files: [__FILE__]
+        end
+      end
+
+      def interpret_string input
+        input&.to_s
+      end
+
+      def interpret_boolean input
+        return nil if input.nil?
+        input ? true : false
+      end
+
+      def interpret_labels input
+        return nil if input.nil?
+        input.to_h do |k, v|
+          v_converted =
+            case v
+            when Array, Hash
+              JSON.generate v
+            else
+              v.to_s
+            end
+          [k.to_s, v_converted]
+        end
+      end
+    end
+  end
+end

--- a/google-logging-utils/lib/google/logging/source_location.rb
+++ b/google-logging-utils/lib/google/logging/source_location.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Logging
+    ##
+    # An object representing a source location as used by Google Logging.
+    #
+    class SourceLocation
+      ##
+      # Returns a SourceLocation corresponding to the caller.
+      # This basically walks the stack trace backwards until it finds the
+      # first entry not in the `google/logging/message.rb` source file or in
+      # any of the other files optionally listed.
+      #
+      # @param locations [Array<Thread::Backtrace::Location>] The caller stack
+      #     to search. Optional; defaults to the current stack.
+      # @param extra_depth [Integer] Optional extra steps backwards to walk.
+      #     Defaults to 0.
+      # @param omit_files [Array<String,Regexp>] File paths to omit.
+      # @return [SourceLocation,nil] The SourceLocation, or nil if none found.
+      #
+      def self.for_caller locations: nil, extra_depth: 0, omit_files: nil
+        in_file = true
+        omit_files = [__FILE__] + Array(omit_files)
+        (locations || self.caller_locations).each do |loc|
+          if in_file
+            next if omit_files.any? { |pat| pat === loc.absolute_path }
+            in_file = false
+          end
+          extra_depth -= 1
+          next unless extra_depth.negative?
+          return new file: loc.path, line: loc.lineno.to_s, function: loc.base_label
+        end
+        nil
+      end
+
+      ##
+      # Low-level constructor.
+      #
+      # @param file [String] Path to the source file.
+      # @param line [String] Line number as a string.
+      # @param function [String] Name of the calling function.
+      #
+      def initialize file:, line:, function:
+        @file = file.to_s
+        @line = line.to_s
+        @function = function.to_s
+      end
+
+      # @return [String] Path to the source file.
+      attr_reader :file
+
+      # @return [String] Line number as a string.
+      attr_reader :line
+
+      # @return [String] Name of the calling function.
+      attr_reader :function
+
+      # @private
+      def to_h
+        {
+          file: @file,
+          line: @line,
+          function: @function
+        }
+      end
+
+      # @private
+      def == other
+        return false unless other.is_a? SourceLocation
+        file == other.file && line == other.line && function == other.function
+      end
+      alias eql? ==
+
+      # @private
+      def hash
+        [file, line, function].hash
+      end
+    end
+  end
+end

--- a/google-logging-utils/lib/google/logging/structured_formatter.rb
+++ b/google-logging-utils/lib/google/logging/structured_formatter.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "json"
+require "google/logging/message"
+
+module Google
+  module Logging
+    ##
+    # A log formatter that outputs the JSON-based structured logging format
+    # (https://cloud.google.com/logging/docs/structured-logging) understood by
+    # Google's logging agent.
+    #
+    class StructuredFormatter
+      # @private
+      CLOUD_SEVERITY = Hash.new { |_h, k| k }.merge(
+        "WARN" => "WARNING",
+        "FATAL" => "CRITICAL",
+        "ANY" => "DEFAULT"
+      ).freeze
+
+      # @private
+      def call severity, time, progname, msg
+        msg = Message.from msg
+        time = msg.timestamp || time
+        struct = {
+          "severity" => CLOUD_SEVERITY[severity],
+          "message" => msg.message,
+          "timestamp" => {
+            "seconds" => time.to_i,
+            "nanos" => time.nsec
+          }
+        }
+        struct.merge! msg.fields if msg.fields
+        struct["logging.googleapis.com/sourceLocation"] = msg.source_location.to_h if msg.source_location
+        struct["logging.googleapis.com/insertId"] = msg.insert_id if msg.insert_id
+        struct["logging.googleapis.com/spanId"] = msg.span_id if msg.span_id
+        struct["logging.googleapis.com/trace"] = msg.trace if msg.trace
+        struct["logging.googleapis.com/traceSampled"] = msg.trace_sampled if msg.trace_sampled
+        struct["logging.googleapis.com/labels"] = msg.labels if msg.labels
+        struct["progname"] ||= progname if progname
+        content = JSON.generate struct
+        "#{content}\n"
+      end
+    end
+  end
+end

--- a/google-logging-utils/lib/google/logging/utils.rb
+++ b/google-logging-utils/lib/google/logging/utils.rb
@@ -14,4 +14,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "google/logging/utils"
+require "google/logging/utils/version"
+require "google/logging/message"
+require "google/logging/source_location"
+require "google/logging/structured_formatter"
+
+##
+# Google products namespace
+#
+module Google
+  ##
+  # Classes and utilities related to logging to and from Google products
+  #
+  module Logging
+    ##
+    # Logging utilities namespace
+    #
+    module Utils
+    end
+  end
+end

--- a/google-logging-utils/test/message_test.rb
+++ b/google-logging-utils/test/message_test.rb
@@ -1,0 +1,327 @@
+# frozen_string_literal: true
+
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+require "logger"
+require "stringio"
+require "google/logging/message"
+
+describe Google::Logging::Message do
+  let(:sample_file) { "/path/to/file" }
+  let(:sample_line_int) { 1234 }
+  let(:sample_line) { sample_line_int.to_s }
+  let(:sample_function) { "migrate_to_ruby" }
+  let(:sample_location) {
+    Google::Logging::SourceLocation.new file: sample_file, line: sample_line_int, function: sample_function
+  }
+
+  describe "#== and #hash" do
+    it "detects equal messages" do
+      msg1 = Google::Logging::Message.new message: :hello
+      msg2 = Google::Logging::Message.new message: "hello"
+      assert_equal msg1, msg2
+      assert_equal msg1.hash, msg2.hash
+    end
+
+    it "detects unequal messages" do
+      msg1 = Google::Logging::Message.new message: "hello2"
+      msg2 = Google::Logging::Message.new message: "hello1"
+      refute_equal msg1, msg2
+      refute_equal msg1.hash, msg2.hash
+    end
+  end
+
+  describe "#message" do
+    it "constructs from a message string" do
+      msg = Google::Logging::Message.new message: :hello
+      assert_equal "hello", msg.message
+      assert_equal "hello", msg.to_s
+    end
+
+    it "constructs from a set of fields" do
+      msg = Google::Logging::Message.new fields: {foo: 1, bar: 2}
+      assert_equal '{"foo":1,"bar":2}', msg.message
+      assert_equal '{"foo":1,"bar":2}', msg.to_s
+    end
+
+    it "constructs from a message string and fields" do
+      msg = Google::Logging::Message.new message: :hello, fields: {foo: 1, bar: 2}
+      assert_equal "hello", msg.message
+      assert_equal "hello", msg.to_s
+    end
+  end
+
+  describe "#full_message" do
+    it "constructs from a message string" do
+      msg = Google::Logging::Message.new message: :hello
+      assert_equal "hello", msg.full_message
+      assert_equal "hello", msg.inspect
+    end
+
+    it "constructs from a set of fields" do
+      msg = Google::Logging::Message.new fields: {foo: 1, bar: 2}
+      assert_equal '{"foo":1,"bar":2}', msg.full_message
+      assert_equal '{"foo":1,"bar":2}', msg.inspect
+    end
+
+    it "constructs from a message string and fields" do
+      msg = Google::Logging::Message.new message: :hello, fields: {foo: 1, bar: 2}
+      assert_equal 'hello -- {"foo":1,"bar":2}', msg.full_message
+      assert_equal 'hello -- {"foo":1,"bar":2}', msg.inspect
+    end
+  end
+
+  describe "#fields" do
+    it "is nil when fields were not used" do
+      msg = Google::Logging::Message.new message: :hello
+      assert_nil msg.fields
+    end
+
+    it "normalizes" do
+      input = {
+        "sym" => :foo,
+        str: "bar",
+        numeric: -1.5,
+        null: nil,
+        array: [1, "two", {ruby: "rules"}],
+        hash: {
+          "sym" => :baz,
+          str: "qux",
+          nested: ["ruby", :rules]
+        }
+      }
+      expected = {
+        "sym" => "foo",
+        "str" => "bar",
+        "numeric" => -1.5,
+        "null" => nil,
+        "array" => [1, "two", {"ruby" => "rules"}],
+        "hash" => {
+          "sym" => "baz",
+          "str" => "qux",
+          "nested" => ["ruby", "rules"]
+        }
+      }
+      msg = Google::Logging::Message.new fields: input
+      assert_equal expected, msg.fields
+    end
+
+    [
+      :severity,
+      :message,
+      :log,
+      :httpRequest,
+      :timestamp,
+      "logging.googleapis.com/insertId"
+    ].each do |bad_field|
+      it "disallows #{bad_field} field" do
+        ex = assert_raises ArgumentError do
+          Google::Logging::Message.new fields: {bad_field => "max"}
+        end
+        assert_equal "Field key not allowed: #{bad_field}", ex.message
+      end
+    end
+  end
+
+  describe "#timestamp" do
+    let(:time_secs) { 123456789 }
+    let(:time_obj) { Time.at time_secs }
+
+    it "supports nil" do
+      msg = Google::Logging::Message.new message: :hello
+      assert_nil msg.timestamp
+    end
+
+    it "supports a time object input" do
+      msg = Google::Logging::Message.new message: :hello, timestamp: time_obj
+      assert_equal time_obj, msg.timestamp
+    end
+
+    it "supports a numeric input" do
+      msg = Google::Logging::Message.new message: :hello, timestamp: time_secs
+      assert_equal time_obj, msg.timestamp
+    end
+
+    it "supports :now as input" do
+      msg = Google::Logging::Message.new message: :hello, timestamp: :now
+      assert_kind_of Time, msg.timestamp
+    end
+  end
+
+  describe "#source_location" do
+    let(:sample_file) { "/path/to/file" }
+    let(:sample_line) { "1234" }
+    let(:sample_function) { "migrate_to_ruby" }
+    let(:sample_location) {
+      Google::Logging::SourceLocation.new file: sample_file, line: sample_line, function: sample_function
+    }
+
+    it "supports nil" do
+      msg = Google::Logging::Message.new message: :hello
+      assert_nil msg.source_location
+    end
+
+    it "supports a SourceLocation object input" do
+      msg = Google::Logging::Message.new message: :hello, source_location: sample_location
+      assert_equal sample_location, msg.source_location
+    end
+
+    it "supports hash input" do
+      input = {
+        file: sample_file,
+        line: sample_line,
+        function: sample_function
+      }
+      msg = Google::Logging::Message.new message: :hello, source_location: input
+      assert_equal sample_location, msg.source_location
+    end
+
+    it "supports :caller input" do
+      expected_line = (__LINE__ + 1).to_s
+      msg = Google::Logging::Message.new message: :hello, source_location: :caller
+      loc = msg.source_location
+      assert_equal __FILE__, loc.file
+      assert_equal expected_line, loc.line
+    end
+  end
+
+  describe "string fields" do
+    let(:sample_insert_id) { "123" }
+    let(:sample_trace) { "projects/hello/trace/ruby" }
+    let(:sample_span_id) { "456" }
+
+    it "supports nil" do
+      msg = Google::Logging::Message.new message: :hello
+      assert_nil msg.insert_id
+      assert_nil msg.trace
+      assert_nil msg.span_id
+    end
+
+    it "supports string input" do
+      msg = Google::Logging::Message.new message: :hello,
+                                         insert_id: sample_insert_id,
+                                         trace: sample_trace,
+                                         span_id: sample_span_id
+      assert_equal sample_insert_id, msg.insert_id
+      assert_equal sample_trace, msg.trace
+      assert_equal sample_span_id, msg.span_id
+    end
+
+    it "supports non-string input" do
+      msg = Google::Logging::Message.new message: :hello,
+                                         insert_id: sample_insert_id.to_i,
+                                         trace: sample_trace.to_sym,
+                                         span_id: sample_span_id.to_i
+      assert_equal sample_insert_id, msg.insert_id
+      assert_equal sample_trace, msg.trace
+      assert_equal sample_span_id, msg.span_id
+    end
+  end
+
+  describe "#trace_sampled" do
+    it "supports nil" do
+      msg = Google::Logging::Message.new message: :hello
+      assert_nil msg.trace_sampled
+      assert_nil msg.trace_sampled?
+    end
+
+    it "supports truthy" do
+      msg = Google::Logging::Message.new message: :hello, trace_sampled: 1
+      assert_equal true, msg.trace_sampled
+      assert_equal true, msg.trace_sampled?
+    end
+
+    it "supports falsy" do
+      msg = Google::Logging::Message.new message: :hello, trace_sampled: false
+      assert_equal false, msg.trace_sampled
+      assert_equal false, msg.trace_sampled?
+    end
+  end
+
+  describe "#labels" do
+    it "supports nil" do
+      msg = Google::Logging::Message.new message: :hello
+      assert_nil msg.labels
+    end
+
+    it "normalizes" do
+      input = {
+        "sym" => :foo,
+        str: "bar",
+        numeric: -1.5,
+        null: nil,
+        array: [1, "two"],
+        hash: {
+          "sym" => :baz,
+          str: "qux",
+        }
+      }
+      expected = {
+        "sym" => "foo",
+        "str" => "bar",
+        "numeric" => "-1.5",
+        "null" => "",
+        "array" => '[1,"two"]',
+        "hash" => '{"sym":"baz","str":"qux"}'
+      }
+      msg = Google::Logging::Message.new message: :hello, labels: input
+      assert_equal expected, msg.labels
+    end
+  end
+
+  describe ".from" do
+    let(:sample_insert_id) { "123456789" }
+    let(:fields_hash) { {"foo" => 1, "bar" => 2} }
+
+    it "interprets a hash as fields and kwargs" do
+      msg = Google::Logging::Message.from insert_id: sample_insert_id, **fields_hash
+      assert_equal '{"foo":1,"bar":2}', msg.message
+      assert_equal fields_hash, msg.fields
+      assert_equal sample_insert_id, msg.insert_id
+    end
+
+    it "merges fields and the :fields kwarg" do
+      msg = Google::Logging::Message.from insert_id: sample_insert_id, fields: {foo: 1}, "bar" => 2
+      assert_equal '{"foo":1,"bar":2}', msg.message
+      assert_equal fields_hash, msg.fields
+      assert_equal sample_insert_id, msg.insert_id
+    end
+
+    it "interprets a message" do
+      original = Google::Logging::Message.new message: :hello, fields: fields_hash
+      msg = Google::Logging::Message.from original
+      assert_same original, msg
+    end
+
+    it "interprets a stringy value" do
+      msg = Google::Logging::Message.from 12345
+      assert_equal "12345", msg.message
+      assert_nil msg.fields
+    end
+  end
+
+  describe "logging" do
+    let(:io) { StringIO.new }
+    let(:logger) { Logger.new io, progname: "myprog" }
+
+    it "formats using the text message by default" do
+      msg = Google::Logging::Message.from "Hello Ruby"
+      logger.warn msg
+      str = io.string
+      assert str.end_with? "-- myprog: Hello Ruby\n"
+    end
+  end
+end

--- a/google-logging-utils/test/source_location_test.rb
+++ b/google-logging-utils/test/source_location_test.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+require "google/logging/source_location"
+
+describe Google::Logging::SourceLocation do
+  let(:sample_file) { "/path/to/file" }
+  let(:sample_line_int) { 1234 }
+  let(:sample_line) { sample_line_int.to_s }
+  let(:sample_function) { "migrate_to_ruby" }
+  let(:sample_location) {
+    Google::Logging::SourceLocation.new file: sample_file, line: sample_line_int, function: sample_function
+  }
+  let(:duplicate_location) {
+    Google::Logging::SourceLocation.new file: sample_file, line: sample_line_int, function: sample_function
+  }
+
+  it "sets fields" do
+    assert_equal sample_file, sample_location.file
+    assert_equal sample_line, sample_location.line
+    assert_equal sample_function, sample_location.function
+  end
+
+  it "converts to a hash" do
+    expected = {
+      file: sample_file,
+      line: sample_line,
+      function: sample_function
+    }
+    assert_equal expected, sample_location.to_h
+  end
+
+  it "tests equality" do
+    assert_equal sample_location, duplicate_location
+    assert_equal sample_location.hash, duplicate_location.hash
+  end
+
+  def immediate_caller_line_loc
+    expected_line = (__LINE__ + 1).to_s
+    loc = Google::Logging::SourceLocation.for_caller
+    [expected_line, loc]
+  end
+
+  def nested_caller_line_loc
+    expected_line = (__LINE__ + 1).to_s
+    loc = nested_make_loc
+    [expected_line, loc]
+  end
+
+  def nested_make_loc
+    Google::Logging::SourceLocation.for_caller extra_depth: 1
+  end
+
+  it "gets the caller info" do
+    expected_line, loc = immediate_caller_line_loc
+    assert_equal __FILE__, loc.file
+    assert_equal expected_line, loc.line
+    assert_equal "immediate_caller_line_loc", loc.function
+  end
+
+  it "gets the caller info with extra_depth" do
+    expected_line, loc = nested_caller_line_loc
+    assert_equal __FILE__, loc.file
+    assert_equal expected_line, loc.line
+    assert_equal "nested_caller_line_loc", loc.function
+  end
+end

--- a/google-logging-utils/test/structured_formatter_test.rb
+++ b/google-logging-utils/test/structured_formatter_test.rb
@@ -1,0 +1,170 @@
+# frozen_string_literal: true
+
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+require "json"
+require "logger"
+require "stringio"
+require "google/logging/structured_formatter"
+
+describe Google::Logging::StructuredFormatter do
+  let(:io) { StringIO.new }
+  let(:formatter) { Google::Logging::StructuredFormatter.new }
+  let(:progname) { "tron" }
+  let(:logger) { Logger.new io, level: Logger::DEBUG, progname: progname, formatter: formatter }
+  let(:log_entries) { io.string.split("\n").map { |line| JSON.load line } }
+
+  it "logs a simple string" do
+    logger.info "hello ruby"
+    assert_equal "hello ruby", log_entries.first["message"]
+  end
+
+  it "logs a hash of stuff" do
+    stuff = { "foo" => "bar", "baz" => [1, 2, 3], message: "hello ruby" }
+    logger.info stuff
+    assert_equal "hello ruby", log_entries.first["message"]
+    assert_equal "bar", log_entries.first["foo"]
+    assert_equal [1, 2, 3], log_entries.first["baz"]
+  end
+
+  it "logs a message object" do
+    logger.info Google::Logging::Message.from "hello message"
+    assert_equal "hello message", log_entries.first["message"]
+  end
+
+  it "escapes newlines" do
+    logger.debug "hello\nruby"
+    assert_equal "hello\nruby", log_entries.first["message"]
+  end
+
+  it "recognizes debug severity" do
+    logger.debug "hello ruby"
+    assert_equal "DEBUG", log_entries.first["severity"]
+  end
+
+  it "recognizes info severity" do
+    logger.info "hello ruby"
+    assert_equal "INFO", log_entries.first["severity"]
+  end
+
+  it "recognizes warning severity" do
+    logger.warn "hello ruby"
+    assert_equal "WARNING", log_entries.first["severity"]
+  end
+
+  it "recognizes error severity" do
+    logger.error "hello ruby"
+    assert_equal "ERROR", log_entries.first["severity"]
+  end
+
+  it "recognizes critical severity" do
+    logger.fatal "hello ruby"
+    assert_equal "CRITICAL", log_entries.first["severity"]
+  end
+
+  it "recognizes any severity" do
+    logger.unknown "hello ruby"
+    assert_equal "DEFAULT", log_entries.first["severity"]
+  end
+
+  it "includes progname" do
+    logger.debug "hello ruby"
+    assert_equal progname, log_entries.first["progname"]
+  end
+
+  it "includes a default time" do
+    logger.debug "hello ruby"
+    assert_kind_of Integer, log_entries.first["timestamp"]["seconds"]
+    assert_kind_of Integer, log_entries.first["timestamp"]["nanos"]
+  end
+
+  it "includes a custom time" do
+    time = Time.at(123456789, 654321, :nsec)
+    msg = Google::Logging::Message.from message: "hello, ruby", timestamp: time
+    logger.info msg
+    assert_equal 123456789, log_entries.first["timestamp"]["seconds"]
+    assert_equal 654321, log_entries.first["timestamp"]["nanos"]
+  end
+
+  it "does not include unset fields" do
+    logger.progname = nil
+    logger.info "hello, ruby"
+    refute log_entries.first.key?("logging.googleapis.com/sourceLocation")
+    refute log_entries.first.key?("logging.googleapis.com/insertId")
+    refute log_entries.first.key?("logging.googleapis.com/spanId")
+    refute log_entries.first.key?("logging.googleapis.com/trace")
+    refute log_entries.first.key?("logging.googleapis.com/traceSampled")
+    refute log_entries.first.key?("logging.googleapis.com/labels")
+    refute log_entries.first.key?("progname")
+  end
+
+  it "includes insert_id" do
+    insert_id = "12345"
+    msg = Google::Logging::Message.from message: "hello, ruby", insert_id: insert_id
+    logger.info msg
+    assert_equal insert_id, log_entries.first["logging.googleapis.com/insertId"]
+  end
+
+  it "includes span_id" do
+    span_id = "12345"
+    msg = Google::Logging::Message.from message: "hello, ruby", span_id: span_id
+    logger.info msg
+    assert_equal span_id, log_entries.first["logging.googleapis.com/spanId"]
+  end
+
+  it "includes trace" do
+    trace = "projects/myproj/trace/hello"
+    msg = Google::Logging::Message.from message: "hello, ruby", trace: trace
+    logger.info msg
+    assert_equal trace, log_entries.first["logging.googleapis.com/trace"]
+  end
+
+  it "includes traceSampled" do
+    msg = Google::Logging::Message.from message: "hello, ruby", trace_sampled: true
+    logger.info msg
+    assert_equal true, log_entries.first["logging.googleapis.com/traceSampled"]
+  end
+
+  it "includes labels" do
+    msg = Google::Logging::Message.from message: "hello, ruby", labels: {foo: "bar"}
+    logger.info msg
+    expected_labels = {"foo" => "bar"}
+    assert_equal expected_labels, log_entries.first["logging.googleapis.com/labels"]
+  end
+
+  def line_and_msg
+    expected_line = (__LINE__ + 1).to_s
+    msg = Google::Logging::Message.from message: "hello, ruby", source_location: :caller
+    [expected_line, msg]
+  end
+
+  it "includes source location" do
+    expected_line, msg = line_and_msg
+    logger.info msg
+    expected_source_location = {
+      "file" => __FILE__,
+      "line" => expected_line,
+      "function" => "line_and_msg"
+    }
+    assert_equal expected_source_location, log_entries.first["logging.googleapis.com/sourceLocation"]
+  end
+
+  it "logs multiple times" do
+    logger.debug "hello ruby"
+    logger.debug "hello again"
+    assert_equal 2, log_entries.size
+  end
+end


### PR DESCRIPTION
This is split into four commits for easier review:

1. `Google::Logging::SourceLocation` class including logic to determine the correct SourceLocation for the caller
2. `Google::Logging::Message` class representing an entire log message, with both text and json payload for display in Google Cloud Logging
3. `Google::Logging::StructuredFormatter` class formatting log messages in [Google Structured Format](https://cloud.google.com/logging/docs/structured-logging).
4. Establish a `google/logging/utils` require path