### PR TITLE
feat(gapic-common): Implement a polling harness

### DIFF
--- a/gapic-common/lib/gapic/call_options.rb
+++ b/gapic-common/lib/gapic/call_options.rb
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "gapic/call_options/error_codes"
 require "gapic/call_options/retry_policy"
+require "gapic/common/error_codes"
 
 module Gapic
   ##

--- a/gapic-common/lib/gapic/call_options/retry_policy.rb
+++ b/gapic-common/lib/gapic/call_options/retry_policy.rb
@@ -12,126 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "gapic/call_options/error_codes"
+require "gapic/common/retry_policy"
 
 module Gapic
   class CallOptions
     ##
-    # The policy for retrying failed RPC calls using an incremental backoff. A new object instance should be used for
-    # every RpcCall invocation.
+    # The policy for retrying failed RPC calls using an incremental backoff. A new object instance
+    # should be used for every RpcCall invocation.
     #
-    # Only errors orginating from GRPC will be retried.
+    # Only errors originating from GRPC will be retried.
     #
-    class RetryPolicy
+    class RetryPolicy < Gapic::Common::RetryPolicy
       ##
       # Create new API Call RetryPolicy.
       #
-      # @param initial_delay [Numeric] client-side timeout
-      # @param multiplier [Numeric] client-side timeout
-      # @param max_delay [Numeric] client-side timeout
+      # @param retry_codes [Array<String|Numeric>] List of retry codes.
+      # @param initial_delay [Numeric] Initial delay in seconds.
+      # @param multiplier [Numeric] The delay scaling factor for each subsequent retry attempt.
+      # @param max_delay [Numeric] Maximum delay in seconds.
       #
       def initialize retry_codes: nil, initial_delay: nil, multiplier: nil, max_delay: nil
-        @retry_codes   = convert_codes retry_codes
-        @initial_delay = initial_delay
-        @multiplier    = multiplier
-        @max_delay     = max_delay
-        @delay         = nil
-      end
-
-      def retry_codes
-        @retry_codes || []
-      end
-
-      def initial_delay
-        @initial_delay || 1
-      end
-
-      def multiplier
-        @multiplier || 1.3
-      end
-
-      def max_delay
-        @max_delay || 15
-      end
-
-      ##
-      # The current delay value.
-      def delay
-        @delay || initial_delay
-      end
-
-      def call error
-        return false unless retry? error
-
-        delay!
-        increment_delay!
-
-        true
-      end
-
-      ##
-      # @private
-      # Apply default values to the policy object. This does not replace user-provided values, it only overrides empty
-      # values.
-      #
-      # @param retry_policy [Hash] The policy for error retry. keys must match the arguments for
-      #   {RpcCall::RetryPolicy.new}.
-      #
-      def apply_defaults retry_policy
-        return unless retry_policy.is_a? Hash
-
-        @retry_codes   ||= convert_codes retry_policy[:retry_codes]
-        @initial_delay ||= retry_policy[:initial_delay]
-        @multiplier    ||= retry_policy[:multiplier]
-        @max_delay     ||= retry_policy[:max_delay]
-
-        self
-      end
-
-      # @private Equality test
-      def eql? other
-        other.is_a?(RetryPolicy) &&
-          other.retry_codes == retry_codes &&
-          other.initial_delay == initial_delay &&
-          other.multiplier == multiplier &&
-          other.max_delay == max_delay
-      end
-      alias == eql?
-
-      # @private Hash code
-      def hash
-        [retry_codes, initial_delay, multiplier, max_delay].hash
-      end
-
-      private
-
-      def retry? error
-        (defined?(::GRPC) && error.is_a?(::GRPC::BadStatus) && retry_codes.include?(error.code)) ||
-          (error.respond_to?(:response_status) &&
-            retry_codes.include?(ErrorCodes.grpc_error_for(error.response_status)))
-      end
-
-      def delay!
-        # Call Kernel.sleep so we can stub it.
-        Kernel.sleep delay
-      end
-
-      def convert_codes input_codes
-        return nil if input_codes.nil?
-        Array(input_codes).map do |obj|
-          case obj
-          when String
-            ErrorCodes::ERROR_STRING_MAPPING[obj]
-          when Integer
-            obj
-          end
-        end.compact
-      end
-
-      ##
-      # Calculate and set the next delay value.
-      def increment_delay!
-        @delay = [delay * multiplier, max_delay].min
+        super
       end
     end
   end

--- a/gapic-common/lib/gapic/common.rb
+++ b/gapic-common/lib/gapic/common.rb
@@ -16,6 +16,7 @@ require "grpc/errors"
 require "grpc/core/status_codes"
 
 require "gapic/common/error"
+require "gapic/common/polling_harness"
 require "gapic/call_options"
 require "gapic/headers"
 require "gapic/operation"

--- a/gapic-common/lib/gapic/common/error_codes.rb
+++ b/gapic-common/lib/gapic/common/error_codes.rb
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 module Gapic
-  class CallOptions
+  module Common
     ##
     # @private
     # The gRPC error codes and their HTTP mapping

--- a/gapic-common/lib/gapic/common/polling_harness.rb
+++ b/gapic-common/lib/gapic/common/polling_harness.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gapic-common/lib/gapic/common/polling_harness.rb
+++ b/gapic-common/lib/gapic/common/polling_harness.rb
@@ -1,0 +1,68 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Gapic
+  module Common
+    ##
+    # Provides a generic mechanism for periodic polling an operation.
+    #
+    # Polling intervals are calculated from the provided retry policy.
+    #
+    # Supports exponential backoff via `multiplier`, and automatically
+    # retries gRPC errors listed in `retry_codes`.
+    #
+    class PollingHarness
+      # @return [Gapic::Common::RetryPolicy] The retry policy associated with this instance.
+      attr_reader :retry_policy
+
+      ##
+      # Create new Gapic::Common::PollingHarness instance.
+      #
+      # @param retry_policy [Gapic::Common::RetryPolicy]
+      #
+      def initialize retry_policy:
+        @retry_policy = retry_policy
+      end
+
+      ##
+      # Perform polling with exponential backoff.
+      #
+      # The provided block MUST evaluate to `nil` in cases where the operation
+      # should continue. Otherwise, the evaluated result will be returned.
+      #
+      # Errors are raised if not listed in `retry_codes`, and re-attempted otherwise.
+      #
+      # The block will be re-attempted indefinitely as long as the retry condition
+      # passes or while a timeout has not been reached.
+      #
+      # @yieldreturn [Object, nil] Custom logic to be retriable.
+      def wait
+        unless block_given?
+          raise ArgumentError, "No callback provided to wait method."
+        end
+        retry_policy.update_deadline!
+        loop do
+          begin
+            response = yield
+            return response unless response.nil?
+          rescue StandardError => e # Currently retry_error only accounts for ::GRPC::BadStatus.
+            raise unless retry_policy.retry_error? e
+          end
+          retry_policy.perform_delay!
+          return response unless retry_policy.retry_with_deadline?
+        end
+      end
+    end
+  end
+end

--- a/gapic-common/lib/gapic/common/polling_harness.rb
+++ b/gapic-common/lib/gapic/common/polling_harness.rb
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "gapic/common/retry_policy"
+
 module Gapic
   module Common
     ##

--- a/gapic-common/lib/gapic/common/polling_harness.rb
+++ b/gapic-common/lib/gapic/common/polling_harness.rb
@@ -29,38 +29,50 @@ module Gapic
       ##
       # Create new Gapic::Common::PollingHarness instance.
       #
-      # @param retry_policy [Gapic::Common::RetryPolicy]
+      # @param retry_policy [Gapic::Common::RetryPolicy] The retry policy to
+      #     use. If not provided, a new retry policy is constructed from the
+      #     given kwargs.
+      # @param kwargs [keywords] Keyword arguments used to create a new retry
+      #     policy. See {RetryPolicy#initialize}.
       #
-      def initialize retry_policy:
-        @retry_policy = retry_policy
+      def initialize retry_policy: nil, **kwargs
+        @retry_policy = retry_policy ? retry_policy.dup : RetryPolicy.new(**kwargs)
       end
 
       ##
-      # Perform polling with exponential backoff.
+      # Perform polling with exponential backoff. Repeatedly calls the given
+      # block until it returns a result other than the given sentinel value
+      # (normally `nil`), then returns that final result.
       #
-      # The provided block MUST evaluate to `nil` in cases where the operation
-      # should continue. Otherwise, the evaluated result will be returned.
+      # Uses the retry policy regulate retries, including delays between tries,
+      # retriable errors, and final timeout. If an error code other than those
+      # listed in {RetryPolicy#retry_codes} is raised, it is propagated out. If
+      # the timeout expires, the given timeout result (normally `nil`) is
+      # returned.
       #
-      # Errors are raised if not listed in `retry_codes`, and re-attempted otherwise.
+      # @param wait_sentinel [Object] The return value that should signal the
+      #     polling harness to continue waiting. Any other value is treated as
+      #     a real result and returned. Defaults to `nil`.
+      # @param timeout_result [Object] The result to return if timeout occurs.
+      #     Defaults to `nil`.
       #
-      # The block will be re-attempted indefinitely as long as the retry condition
-      # passes or while a timeout has not been reached.
+      # @yieldreturn [Object] The result of the polling logic, either a result
+      #     to return, or the `wait_sentinel` value.
       #
-      # @yieldreturn [Object, nil] Custom logic to be retriable.
-      def wait
+      def wait wait_sentinel: nil, timeout_result: nil, mock_delay: false
         unless block_given?
           raise ArgumentError, "No callback provided to wait method."
         end
-        retry_policy.update_deadline!
+        retry_policy.start! mock_delay: mock_delay
         loop do
           begin
             response = yield
-            return response unless response.nil?
+            return response unless response == wait_sentinel
           rescue StandardError => e # Currently retry_error only accounts for ::GRPC::BadStatus.
             raise unless retry_policy.retry_error? e
           end
           retry_policy.perform_delay!
-          return response unless retry_policy.retry_with_deadline?
+          return timeout_result unless retry_policy.retry_with_deadline?
         end
       end
     end

--- a/gapic-common/lib/gapic/common/retry_policy.rb
+++ b/gapic-common/lib/gapic/common/retry_policy.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gapic-common/lib/gapic/common/retry_policy.rb
+++ b/gapic-common/lib/gapic/common/retry_policy.rb
@@ -1,0 +1,205 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "gapic/common/error_codes"
+
+module Gapic
+  module Common
+    # Gapic Common retry policy base class.
+    class RetryPolicy
+      # @return [Numeric] Default initial delay in seconds.
+      DEFAULT_INITIAL_DELAY = 1
+      # @return [Numeric] Default maximum delay in seconds.
+      DEFAULT_MAX_DELAY = 15
+      # @return [Numeric] Default delay scaling factor for subsequent retry attempts.
+      DEFAULT_MULTIPLIER = 1.3
+      # @return [Array<String|Numeric>] Default list of retry codes.
+      DEFAULT_RETRY_CODES = [].freeze
+      # @return [Numeric] Default timeout threshold value in seconds.
+      DEFAULT_TIMEOUT = 3600 # One hour
+
+      ##
+      # Create new Gapic::Common:RetryPolicy instance.
+      #
+      # Instance values are set as `nil` to determine whether values are overriden from default.
+      #
+      # @param initial_delay [Numeric] Initial delay in seconds.
+      # @param max_delay [Numeric] Maximum delay in seconds.
+      # @param multiplier [Numeric] The delay scaling factor for each subsequent retry attempt.
+      # @param retry_codes [Array<String|Numeric>] List of retry codes.
+      # @param timeout [Numeric] Timeout threshold value in seconds.
+      #
+      def initialize initial_delay: nil, max_delay: nil, multiplier: nil, retry_codes: nil, timeout: nil
+        @initial_delay = initial_delay
+        @max_delay = max_delay
+        @multiplier = multiplier
+        @retry_codes = convert_codes retry_codes
+        @timeout = timeout
+        @delay = nil
+      end
+
+      # @return [Numeric] Initial delay in seconds.
+      def initial_delay
+        @initial_delay || DEFAULT_INITIAL_DELAY
+      end
+
+      # @return [Numeric] Maximum delay in seconds.
+      def max_delay
+        @max_delay || DEFAULT_MAX_DELAY
+      end
+
+      # @return [Numeric] The delay scaling factor for each subsequent retry attempt.
+      def multiplier
+        @multiplier || DEFAULT_MULTIPLIER
+      end
+
+      # @return [Array<Numeric>] List of retry codes.
+      def retry_codes
+        @retry_codes || DEFAULT_RETRY_CODES
+      end
+
+      # @return [Numeric] Timeout threshold value in seconds.
+      def timeout
+        @timeout || DEFAULT_TIMEOUT
+      end
+
+      ##
+      # Perform delay if and only if retriable.
+      #
+      # If positional argument `error` is provided, the retriable logic uses
+      # `retry_codes`. Otherwise, `timeout` is used.
+      #
+      # @return [Boolean] Whether the delay was executed.
+      #
+      def call error = nil
+        should_retry = error.nil? ? retry_with_deadline? : retry_error?(error)
+        return false unless should_retry
+        perform_delay!
+      end
+      alias perform_delay call
+
+      ##
+      # Perform delay.
+      #
+      # @return [Boolean] Whether the delay was executed.
+      #
+      def perform_delay!
+        delay!
+        increment_delay!
+        true
+      end
+
+      ##
+      # Current delay value in seconds.
+      #
+      # @return [Numeric] Time delay in seconds.
+      #
+      def delay
+        @delay || initial_delay
+      end
+
+      ##
+      # Sets a deadline based on the current time.
+      #
+      # @return [Numeric] The deadline for timeout-based retry policies.
+      def update_deadline!
+        @deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+      end
+
+      ##
+      # @private
+      # @return [Boolean] Whether this error should be retried.
+      #
+      def retry_error? error
+        (defined?(::GRPC) && error.is_a?(::GRPC::BadStatus) && retry_codes.include?(error.code)) ||
+          (error.respond_to?(:response_status) &&
+            retry_codes.include?(ErrorCodes.grpc_error_for(error.response_status)))
+      end
+
+      # @private
+      # @return [Boolean] Whether this policy should be retried based on the deadline.
+      def retry_with_deadline?
+        deadline > Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      end
+
+      ##
+      # @private
+      # Apply default values to the policy object. This does not replace user-provided values,
+      # it only overrides empty values.
+      #
+      # @param retry_policy [Hash] The policy for error retry. Keys must match the arguments for
+      #   {Gapic::Common::RetryPolicy.new}.
+      #
+      def apply_defaults retry_policy
+        return unless retry_policy.is_a? Hash
+        @retry_codes   ||= convert_codes retry_policy[:retry_codes]
+        @initial_delay ||= retry_policy[:initial_delay]
+        @multiplier    ||= retry_policy[:multiplier]
+        @max_delay     ||= retry_policy[:max_delay]
+
+        self
+      end
+
+      # @private Equality test
+      def eql? other
+        other.is_a?(RetryPolicy) &&
+          other.initial_delay == initial_delay &&
+          other.max_delay == max_delay &&
+          other.multiplier == multiplier &&
+          other.retry_codes == retry_codes &&
+          other.timeout == timeout
+      end
+      alias == eql?
+
+      # @private Hash code
+      def hash
+        [initial_delay, max_delay, multiplier, retry_codes, timeout].hash
+      end
+
+      private
+
+      # @private
+      # @return [Numeric] The performed delay.
+      def delay!
+        Kernel.sleep delay
+      end
+
+      # @private
+      # @return [Numeric] The new delay in seconds.
+      def increment_delay!
+        @delay = [delay * multiplier, max_delay].min
+      end
+
+      # @private
+      # @return [Numeric] The deadline for timeout-based policies.
+      def deadline
+        @deadline ||= update_deadline!
+      end
+
+      # @private
+      # @return [Array<Numeric> Error codes converted to their respective integer values.
+      def convert_codes input_codes
+        return nil if input_codes.nil?
+        Array(input_codes).map do |obj|
+          case obj
+          when String
+            ErrorCodes::ERROR_STRING_MAPPING[obj]
+          when Integer
+            obj
+          end
+        end.compact
+      end
+    end
+  end
+end

--- a/gapic-common/lib/gapic/operation/retry_policy.rb
+++ b/gapic-common/lib/gapic/operation/retry_policy.rb
@@ -12,80 +12,40 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "gapic/common/retry_policy"
+
 module Gapic
   class Operation
     ##
-    # The policy for retrying operation reloads using an incremental backoff. A new object instance should be used for
-    # every Operation invocation.
+    # The policy for retrying operation reloads using an incremental backoff.
     #
-    class RetryPolicy
+    # A new object instance should be used for every Operation invocation.
+    #
+    class RetryPolicy < Gapic::Common::RetryPolicy
+      # @return [Numeric] Default initial delay in seconds.
+      DEFAULT_INITIAL_DELAY = 10
+      # @return [Numeric] Default maximum delay in seconds.
+      DEFAULT_MAX_DELAY = 300 # Five minutes
+      # @return [Numeric] Default delay scaling factor for subsequent retry attempts.
+      DEFAULT_MULTIPLIER = 1.3
+      # @return [Numeric] Default timeout threshold value in seconds.
+      DEFAULT_TIMEOUT = 3600 # One hour
+
       ##
       # Create new Operation RetryPolicy.
       #
-      # @param initial_delay [Numeric] client-side timeout
-      # @param multiplier [Numeric] client-side timeout
-      # @param max_delay [Numeric] client-side timeout
-      # @param timeout [Numeric] client-side timeout
+      # @param initial_delay [Numeric] Initial delay in seconds.
+      # @param multiplier [Numeric] The delay scaling factor for each subsequent retry attempt.
+      # @param max_delay [Numeric] Maximum delay in seconds.
+      # @param timeout [Numeric] Timeout threshold value in seconds.
       #
       def initialize initial_delay: nil, multiplier: nil, max_delay: nil, timeout: nil
-        @initial_delay = initial_delay
-        @multiplier    = multiplier
-        @max_delay     = max_delay
-        @timeout       = timeout
-        @delay         = nil
-      end
-
-      def initial_delay
-        @initial_delay || 10
-      end
-
-      def multiplier
-        @multiplier || 1.3
-      end
-
-      def max_delay
-        @max_delay || 300 # Five minutes
-      end
-
-      def timeout
-        @timeout || 3600 # One hour
-      end
-
-      def call
-        return unless retry?
-
-        delay!
-        increment_delay!
-
-        true
-      end
-
-      private
-
-      def deadline
-        # memoize the deadline
-        @deadline ||= Time.now + timeout
-      end
-
-      def retry?
-        deadline > Time.now
-      end
-
-      ##
-      # The current delay value.
-      def delay
-        @delay || initial_delay
-      end
-
-      def delay!
-        # Call Kernel.sleep so we can stub it.
-        Kernel.sleep delay
-      end
-
-      ##
-      # Calculate and set the next delay value.
-      def increment_delay!
-        @delay = [delay * multiplier, max_delay].min
+        super(
+          initial_delay: initial_delay || DEFAULT_INITIAL_DELAY,
+          max_delay: max_delay || DEFAULT_MAX_DELAY,
+          multiplier: multiplier || DEFAULT_MULTIPLIER,
+          timeout: timeout || DEFAULT_TIMEOUT
+        )
       end
     end
   end

--- a/gapic-common/test/gapic/call_options/retry_policy/call_test.rb
+++ b/gapic-common/test/gapic/call_options/retry_policy/call_test.rb
@@ -54,7 +54,7 @@ class RetryPolicyCallTest < Minitest::Test
     )
     faraday_error = OpenStruct.new response_status: 503
 
-    assert_includes retry_policy.retry_codes, Gapic::CallOptions::ErrorCodes.grpc_error_for(faraday_error.response_status)
+    assert_includes retry_policy.retry_codes, Gapic::Common::ErrorCodes.grpc_error_for(faraday_error.response_status)
 
     sleep_mock = Minitest::Mock.new
     sleep_mock.expect :sleep, nil, [1]
@@ -73,7 +73,7 @@ class RetryPolicyCallTest < Minitest::Test
     )
     faraday_error = OpenStruct.new response_status: nil
 
-    assert_includes retry_policy.retry_codes, Gapic::CallOptions::ErrorCodes.grpc_error_for(faraday_error.response_status)
+    assert_includes retry_policy.retry_codes, Gapic::Common::ErrorCodes.grpc_error_for(faraday_error.response_status)
 
     sleep_mock = Minitest::Mock.new
     sleep_mock.expect :sleep, nil, [1]

--- a/gapic-common/test/gapic/common/polling_harness_test.rb
+++ b/gapic-common/test/gapic/common/polling_harness_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gapic-common/test/gapic/common/polling_harness_test.rb
+++ b/gapic-common/test/gapic/common/polling_harness_test.rb
@@ -1,0 +1,119 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "gapic/common/polling_harness"
+require "gapic/common/retry_policy"
+
+# Test class for Gapic::Common::PollingHarness
+class PollingHarnessTest < Minitest::Test
+  def test_init
+    retry_policy = Gapic::Common::RetryPolicy.new initial_delay: 20
+    polling_harness = Gapic::Common::PollingHarness.new retry_policy: retry_policy
+    assert_equal retry_policy, polling_harness.retry_policy
+  end
+
+  def test_wait_perform_delay_once
+    should_wait = true
+    retry_policy_mock = Minitest::Mock.new
+    retry_policy_mock.expect :update_deadline!, nil, []
+    retry_policy_mock.expect :perform_delay!, nil, []
+    retry_policy_mock.expect :retry_with_deadline?, true, []
+    polling_harness = Gapic::Common::PollingHarness.new retry_policy: retry_policy_mock
+
+    polling_harness.wait do
+      if should_wait
+        should_wait = false
+        nil
+      else
+        should_wait
+      end
+    end
+    retry_policy_mock.verify
+    assert_equal false, should_wait
+  end
+
+  def test_wait_perform_delay_many
+    perform_delay_total = 5
+    retry_policy_mock = Minitest::Mock.new
+    retry_policy_mock.expect :update_deadline!, nil, []
+    polling_harness = Gapic::Common::PollingHarness.new retry_policy: retry_policy_mock
+
+    polling_harness.wait do
+      if perform_delay_total.positive?
+        retry_policy_mock.expect :perform_delay!, nil, []
+        retry_policy_mock.expect :retry_with_deadline?, true, []
+        perform_delay_total -= 1
+        nil
+      else
+        perform_delay_total
+      end
+    end
+    retry_policy_mock.verify
+    assert_equal 0, perform_delay_total
+  end
+
+  def test_wait_with_retriable_code
+    perform_delay_count = 0
+    retry_policy = Gapic::Common::RetryPolicy.new retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE]
+    retry_policy.define_singleton_method :perform_delay! do
+      perform_delay_count += 1
+    end
+    polling_harness = Gapic::Common::PollingHarness.new retry_policy: retry_policy
+
+    should_raise_error = true
+    polling_harness.wait do
+      if should_raise_error
+        should_raise_error = false
+        raise ::GRPC::Unavailable
+      else
+        should_raise_error
+      end
+    end
+    assert_equal 1, perform_delay_count
+  end
+
+  def test_wait_non_retriable_code
+    perform_delay_count = 0
+    retry_policy = Gapic::Common::RetryPolicy.new retry_codes: [GRPC::Core::StatusCodes::RESOURCE_EXHAUSTED]
+    retry_policy.define_singleton_method :perform_delay! do
+      perform_delay_count += 1
+    end
+    polling_harness = Gapic::Common::PollingHarness.new retry_policy: retry_policy
+    assert_raises ::GRPC::Aborted do
+      polling_harness.wait do
+        raise ::GRPC::Aborted
+      end
+    end
+    assert_equal 0, perform_delay_count
+  end
+
+  def test_wait_argument_error
+    retry_policy = Gapic::Common::RetryPolicy.new
+    polling_harness = Gapic::Common::PollingHarness.new retry_policy: retry_policy
+    assert_raises ArgumentError do
+      polling_harness.wait
+    end
+  end
+
+  def test_wait_with_timeout
+    retry_policy = Gapic::Common::RetryPolicy.new initial_delay: 2, multiplier: 1, timeout: 3
+    polling_harness = Gapic::Common::PollingHarness.new retry_policy: retry_policy
+    wait_count = 0
+    polling_harness.wait do
+      wait_count += 1
+      nil
+    end
+    assert_equal 2, wait_count
+  end
+end

--- a/gapic-common/test/gapic/common/retry_policy_test.rb
+++ b/gapic-common/test/gapic/common/retry_policy_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gapic-common/test/gapic/common/retry_policy_test.rb
+++ b/gapic-common/test/gapic/common/retry_policy_test.rb
@@ -1,0 +1,68 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "gapic/common/retry_policy"
+
+# Test class for Gapic::Common::RetryPolicy
+class RetryPolicyTest < Minitest::Test
+  def test_init_with_values
+    retry_policy = Gapic::Common::RetryPolicy.new(
+      initial_delay: 2, max_delay: 20, multiplier: 1.7,
+      retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE], timeout: 600
+    )
+    assert_equal 2, retry_policy.initial_delay
+    assert_equal 20, retry_policy.max_delay
+    assert_equal 1.7, retry_policy.multiplier
+    assert_equal [GRPC::Core::StatusCodes::UNAVAILABLE], retry_policy.retry_codes
+    assert_equal 600, retry_policy.timeout
+  end
+
+  def test_perform_delay_increment_delay
+    retry_policy = Gapic::Common::RetryPolicy.new initial_delay: 1, max_delay: 5, multiplier: 1.3
+    retry_policy.perform_delay!
+    refute_equal retry_policy.initial_delay, retry_policy.delay
+    assert_equal 1.3, retry_policy.delay
+  end
+
+  def test_perform_delay_retry_common_logic
+    retry_policy = Gapic::Common::RetryPolicy.new initial_delay: 3, max_delay: 10, multiplier: 2
+    retry_policy.define_singleton_method :retry? do
+      true
+    end
+    retry_policy.perform_delay
+    assert_equal 6, retry_policy.delay
+  end
+
+  def test_perform_delay_retry_error_logic
+    retry_policy = Gapic::Common::RetryPolicy.new initial_delay: 5, max_delay: 30, multiplier: 3
+    retry_policy.define_singleton_method :retry_error? do |_error|
+      true
+    end
+    retry_policy.perform_delay
+    assert_equal 15, retry_policy.delay
+  end
+
+  def test_max_delay_limit
+    retry_policy = Gapic::Common::RetryPolicy.new initial_delay: 10, max_delay: 12, multiplier: 1.5
+    retry_policy.perform_delay!
+    assert_equal 12, retry_policy.delay
+  end
+
+  def test_retry_policy_deadline_init
+    Process.stub :clock_gettime, 123456789.0 do
+      retry_policy = Gapic::Common::RetryPolicy.new timeout: 10
+      assert_equal 123456799.0, retry_policy.send(:deadline)
+    end
+  end
+end

--- a/gapic-common/test/gapic/common/retry_policy_test.rb
+++ b/gapic-common/test/gapic/common/retry_policy_test.rb
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "test_helper"
+
 require "gapic/common/retry_policy"
 
 # Test class for Gapic::Common::RetryPolicy
@@ -30,6 +32,7 @@ class RetryPolicyTest < Minitest::Test
 
   def test_perform_delay_increment_delay
     retry_policy = Gapic::Common::RetryPolicy.new initial_delay: 1, max_delay: 5, multiplier: 1.3
+    retry_policy.start! mock_delay: true
     retry_policy.perform_delay!
     refute_equal retry_policy.initial_delay, retry_policy.delay
     assert_equal 1.3, retry_policy.delay
@@ -40,6 +43,7 @@ class RetryPolicyTest < Minitest::Test
     retry_policy.define_singleton_method :retry? do
       true
     end
+    retry_policy.start! mock_delay: true
     retry_policy.perform_delay
     assert_equal 6, retry_policy.delay
   end
@@ -49,12 +53,14 @@ class RetryPolicyTest < Minitest::Test
     retry_policy.define_singleton_method :retry_error? do |_error|
       true
     end
+    retry_policy.start! mock_delay: true
     retry_policy.perform_delay
     assert_equal 15, retry_policy.delay
   end
 
   def test_max_delay_limit
     retry_policy = Gapic::Common::RetryPolicy.new initial_delay: 10, max_delay: 12, multiplier: 1.5
+    retry_policy.start! mock_delay: true
     retry_policy.perform_delay!
     assert_equal 12, retry_policy.delay
   end

--- a/gapic-common/test/gapic/generic_lro_test.rb
+++ b/gapic-common/test/gapic/generic_lro_test.rb
@@ -328,11 +328,11 @@ class GenericLROTest < Minitest::Test
 
     Kernel.stub :sleep, sleep_proc do
       time_now = Time.now
-      incrementing_time = lambda do
+      incrementing_time = lambda do |_clock|
         delay = sleep_counts.shift || 160
         time_now += delay
       end
-      Time.stub :now, incrementing_time do
+      Process.stub :clock_gettime, incrementing_time do
         retry_config = { initial_delay: 10, multiplier: 2, max_delay: (5 * 60), timeout: 400 }
         op.wait_until_done! retry_policy: retry_config
         refute op.done?

--- a/gapic-common/test/gapic/generic_lro_test.rb
+++ b/gapic-common/test/gapic/generic_lro_test.rb
@@ -253,24 +253,10 @@ class GenericLROTest < Minitest::Test
     mock_client = MockLroClient.new get_method: get_method
     op = create_op MockOperation.new(status: :NOTDONE, name: NAME), client: mock_client
 
-    sleep_counts = [10.0, 13.0, 16.900000000000002]
-    sleep_mock = Minitest::Mock.new
-    sleep_counts.each do |sleep_count|
-      sleep_mock.expect :sleep, nil, [sleep_count]
-    end
+    retry_policy = Gapic::Operation::RetryPolicy.new
+    retry_policy.start! mock_delay: true
+    op.wait_until_done! retry_policy: retry_policy
 
-    sleep_proc = ->(count) do 
-      sleep_mock.sleep count 
-    end
-
-    Kernel.stub :sleep, sleep_proc do
-      time_now = Time.now
-      Time.stub :now, time_now do
-        op.wait_until_done!
-      end
-    end
-
-    sleep_mock.verify
     assert_equal 0, to_call
   end
 
@@ -291,24 +277,10 @@ class GenericLROTest < Minitest::Test
       reload_called += 1
     end
 
-    sleep_counts = [10.0, 13.0, 16.900000000000002]
-    sleep_mock = Minitest::Mock.new
-    sleep_counts.each do |sleep_count|
-      sleep_mock.expect :sleep, nil, [sleep_count]
-    end
+    retry_policy = Gapic::Operation::RetryPolicy.new
+    retry_policy.start! mock_delay: true
+    op.wait_until_done! retry_policy: retry_policy
 
-    sleep_proc = ->(count) do 
-      sleep_mock.sleep count 
-    end
-
-    Kernel.stub :sleep, sleep_proc do
-      time_now = Time.now
-      Time.stub :now, time_now do
-        op.wait_until_done!
-      end
-    end
-
-    sleep_mock.verify
     assert_equal 0, to_call
     assert_equal 3, reload_called
   end
@@ -319,27 +291,11 @@ class GenericLROTest < Minitest::Test
     mock_client = MockLroClient.new get_method: get_method
     op = create_op MockOperation.new(status: :NOTDONE, name: NAME), client: mock_client
 
-    sleep_counts = [10, 20, 40, 80]
-    sleep_mock = Minitest::Mock.new
-    sleep_counts.each do |sleep_count|
-      sleep_mock.expect :sleep, nil, [sleep_count]
-    end
-    sleep_proc = ->(count) { sleep_mock.sleep count }
-
-    Kernel.stub :sleep, sleep_proc do
-      time_now = Time.now
-      incrementing_time = lambda do |_clock|
-        delay = sleep_counts.shift || 160
-        time_now += delay
-      end
-      Process.stub :clock_gettime, incrementing_time do
-        retry_config = { initial_delay: 10, multiplier: 2, max_delay: (5 * 60), timeout: 400 }
-        op.wait_until_done! retry_policy: retry_config
-        refute op.done?
-      end
-    end
-
-    sleep_mock.verify
+    retry_policy = Gapic::Operation::RetryPolicy.new initial_delay: 10, multiplier: 2,
+                                                     max_delay: (5 * 60), timeout: 400
+    retry_policy.start! mock_delay: true
+    op.wait_until_done! retry_policy: retry_policy
+    refute op.done?
   end
 
   # Retry options are applied correctly
@@ -356,27 +312,16 @@ class GenericLROTest < Minitest::Test
     mock_client = MockLroClient.new get_method: get_method
     op = create_op MockOperation.new(status: :NOT_DONE, name: NAME), client: mock_client
 
-    sleep_counts = [10, 20, 40, 80, 160, 300, 300, 300, 300, 300]
-    sleep_mock = Minitest::Mock.new
-    sleep_counts.each do |sleep_count|
-      sleep_mock.expect :sleep, nil, [sleep_count]
+    expected_delays = [10, 20, 40, 80, 160, 300, 300, 300, 300, 300]
+    delays_tester = proc do |delay|
+      assert_equal expected_delays.shift, delay
     end
-    sleep_proc = ->(count) { sleep_mock.sleep count }
-
-    Kernel.stub :sleep, sleep_proc do
-      time_now = Time.now
-      incrementing_time = lambda do
-        delay = sleep_counts.shift || 300
-        time_now += delay
-      end
-      Time.stub :now, incrementing_time do
-        retry_config = { initial_delay: 10, multiplier: 2, max_delay: (5 * 60), timeout: (60 * 60) }
-        op.wait_until_done! retry_policy: retry_config
-        assert op.done?
-      end
-    end
-
-    sleep_mock.verify
+    retry_policy = Gapic::Operation::RetryPolicy.new initial_delay: 10, multiplier: 2,
+                                                      max_delay: (5 * 60), timeout: (60 * 60)
+    retry_policy.start! mock_delay: delays_tester
+    op.wait_until_done! retry_policy: retry_policy
+    assert op.done?
+    assert expected_delays.empty?
   end
 
   # On_done callback is triggered if operation is Done before wrapping

--- a/gapic-common/test/gapic/grpc/bad_status/status_details_test.rb
+++ b/gapic-common/test/gapic/grpc/bad_status/status_details_test.rb
@@ -15,6 +15,7 @@
 require "test_helper"
 require "gapic/grpc"
 require "google/rpc/error_details_pb"
+require "google/rpc/status_pb"
 require "google/protobuf/timestamp_pb"
 
 class GrpcBadStatusStatusDetailsTest < Minitest::Test

--- a/gapic-common/test/gapic/operation_test.rb
+++ b/gapic-common/test/gapic/operation_test.rb
@@ -420,12 +420,12 @@ describe Gapic::Operation do
       sleep_proc = ->(count) { sleep_mock.sleep count }
 
       Kernel.stub :sleep, sleep_proc do
-        time_now = Time.now
-        incrementing_time = lambda do
+        time_now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        incrementing_time = lambda do |_clock|
           delay = sleep_counts.shift || 160
           time_now += delay
         end
-        Time.stub :now, incrementing_time do
+        Process.stub :clock_gettime, incrementing_time do
           retry_config = { initial_delay: 10, multiplier: 2, max_delay: (5 * 60), timeout: 400 }
           op.wait_until_done! retry_policy: retry_config
           _(op).wont_be :done?

--- a/gapic-common/test/test_helper.rb
+++ b/gapic-common/test/test_helper.rb
@@ -30,8 +30,8 @@ require_relative "./fixtures/transcoding_example_pb"
 
 class FakeFaradayError < ::Faraday::Error
   def initialize code
-    if code < 100 && ::Gapic::CallOptions::ErrorCodes::HTTP_GRPC_CODE_MAP.invert.key?(code)
-      code = ::Gapic::CallOptions::ErrorCodes::HTTP_GRPC_CODE_MAP.invert[code]
+    if code < 100 && ::Gapic::Common::ErrorCodes::HTTP_GRPC_CODE_MAP.invert.key?(code)
+      code = ::Gapic::Common::ErrorCodes::HTTP_GRPC_CODE_MAP.invert[code]
     end
 
     @code = code
@@ -42,7 +42,7 @@ class FakeFaradayError < ::Faraday::Error
   end
 
   def grpc_code
-    ::Gapic::CallOptions::ErrorCodes::HTTP_GRPC_CODE_MAP[@code]
+    ::Gapic::Common::ErrorCodes::HTTP_GRPC_CODE_MAP[@code]
   end
 
   def response_status


### PR DESCRIPTION
Reproduces @aandreassa 's original implementation from https://github.com/googleapis/gapic-generator-ruby/tree/gapic-polling-harness in the first commit. Provides some revisions in the second commit.