### PR TITLE
chore: Update release job configs

### DIFF
--- a/.kokoro/release.cfg
+++ b/.kokoro/release.cfg
@@ -13,7 +13,7 @@ build_file: "ruby-core-libraries/.kokoro/trampoline_v2.sh"
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "us-central1-docker.pkg.dev/cloud-sdk-release-custom-pool/release-images/ruby-multi"
+  value: "us-central1-docker.pkg.dev/cloud-sdk-release-custom-pool/release-images/ruby-release"
 }
 
 env_vars: {
@@ -28,7 +28,7 @@ env_vars: {
 
 env_vars: {
   key: "SECRET_MANAGER_KEYS"
-  value: "releasetool-publish-reporter-app,releasetool-publish-reporter-googleapis-installation,releasetool-publish-reporter-pem,docuploader_service_account"
+  value: "releasetool-publish-reporter-app,releasetool-publish-reporter-googleapis-installation,releasetool-publish-reporter-pem"
 }
 
 # Pick up Rubygems key from internal keystore

--- a/.kokoro/release.sh
+++ b/.kokoro/release.sh
@@ -7,5 +7,4 @@ set -eo pipefail
 export GEM_HOME=$HOME/.gem
 export PATH=$GEM_HOME/bin:$PATH
 
-gem install --no-document toys
-toys release perform -v --reporter-org=googleapis --force-republish --enable-docs --enable-rad < /dev/null
+toys release perform -v --reporter-org=googleapis --force-republish --enable-rad < /dev/null


### PR DESCRIPTION
Details:

* Switched release job to use the dedicated release image instead of the one shared with CI jobs
* Stopped loading docuploader_credentials from secret manager in favor of using ADC
* Stopped installing toys from the release script since it is present in the image already
* Stopped uploading documentation to googleapis.dev (but retained upload to cloud-rad)