### PR TITLE
fix(gapic-common): Removed log preprocessing of large payload data when logging is disabled

### DIFF
--- a/gapic-common/lib/gapic/grpc/service_stub/rpc_call.rb
+++ b/gapic-common/lib/gapic/grpc/service_stub/rpc_call.rb
@@ -183,7 +183,7 @@ module Gapic
       end
 
       def log_request request, metadata, try_number
-        return request unless @stub_logger
+        return request unless @stub_logger&.enabled?
         @stub_logger.info do |entry|
           entry.set_system_name
           entry.set_service
@@ -221,7 +221,7 @@ module Gapic
       end
 
       def log_response response, try_number
-        return response unless @stub_logger
+        return response unless @stub_logger&.enabled?
         @stub_logger.info do |entry|
           entry.set_system_name
           entry.set_service

--- a/gapic-common/lib/gapic/logging_concerns.rb
+++ b/gapic-common/lib/gapic/logging_concerns.rb
@@ -42,6 +42,10 @@ module Gapic
         @kwargs = kwargs
       end
 
+      def enabled?
+        !!@logger
+      end
+
       def log severity
         return unless @logger
         locations = caller_locations

--- a/gapic-common/lib/gapic/rest/client_stub.rb
+++ b/gapic-common/lib/gapic/rest/client_stub.rb
@@ -278,7 +278,7 @@ module Gapic
       end
 
       def log_request method_name, request_id, try_number, body, metadata
-        return unless stub_logger
+        return unless stub_logger&.enabled?
         stub_logger.info do |entry|
           entry.set_system_name
           entry.set_service
@@ -299,7 +299,7 @@ module Gapic
       end
 
       def log_response method_name, request_id, try_number, response, is_server_streaming
-        return unless stub_logger
+        return unless stub_logger&.enabled?
         stub_logger.info do |entry|
           entry.set_system_name
           entry.set_service


### PR DESCRIPTION
The request/response logging code is doing preprocessing (generally calling `to_h` or `to_s` on response objects) even if logging is disabled. The preprocessed data is unused, but the process is using both time and memory, especially for large payloads. (See https://github.com/googleads/google-ads-ruby/issues/519) This change strengthens the check to ensure the entire logging code is skipped if logging is disabled. Tests are included.