### PR TITLE
feat: add jitter to retries

### DIFF
--- a/gapic-common/lib/gapic/call_options/retry_policy.rb
+++ b/gapic-common/lib/gapic/call_options/retry_policy.rb
@@ -30,8 +30,9 @@ module Gapic
       # @param initial_delay [Numeric] Initial delay in seconds.
       # @param multiplier [Numeric] The delay scaling factor for each subsequent retry attempt.
       # @param max_delay [Numeric] Maximum delay in seconds.
+      # @param jitter [Numeric] Random jitter added to the delay in seconds.
       #
-      def initialize retry_codes: nil, initial_delay: nil, multiplier: nil, max_delay: nil
+      def initialize retry_codes: nil, initial_delay: nil, multiplier: nil, max_delay: nil, jitter: nil
         super
       end
     end

--- a/gapic-common/lib/gapic/common/retry_policy.rb
+++ b/gapic-common/lib/gapic/common/retry_policy.rb
@@ -31,6 +31,11 @@ module Gapic
       # @return [Numeric] Default timeout threshold value in seconds.
       DEFAULT_TIMEOUT = 3600 # One hour
 
+      # @private
+      # @return [Numeric] Default random jitter added to delay in seconds.
+      DEFAULT_JITTER = 1.0
+      private_constant :DEFAULT_JITTER
+
       ##
       # Create new Gapic::Common::RetryPolicy instance.
       #
@@ -39,14 +44,18 @@ module Gapic
       # @param multiplier [Numeric] The delay scaling factor for each subsequent retry attempt.
       # @param retry_codes [Array<String|Integer>] List of retry codes.
       # @param timeout [Numeric] Timeout threshold value in seconds.
+      # @param jitter [Numeric] Random jitter added to the delay in seconds.
       #
-      def initialize initial_delay: nil, max_delay: nil, multiplier: nil, retry_codes: nil, timeout: nil
+      def initialize initial_delay: nil, max_delay: nil, multiplier: nil, retry_codes: nil, timeout: nil, jitter: nil
+        raise ArgumentError, "jitter cannot be negative" if jitter&.negative?
+
         # Instance values are set as `nil` to determine whether values are overriden from default.
         @initial_delay = initial_delay
         @max_delay = max_delay
         @multiplier = multiplier
         @retry_codes = convert_codes retry_codes
         @timeout = timeout
+        @jitter = jitter
         start!
       end
 
@@ -75,6 +84,11 @@ module Gapic
         @timeout || DEFAULT_TIMEOUT
       end
 
+      # @return [Numeric] Random jitter added to the delay in seconds.
+      def jitter
+        @jitter || DEFAULT_JITTER
+      end
+
       ##
       # Returns a duplicate in a non-executing state, i.e. with the deadline
       # and current delay reset.
@@ -86,7 +100,8 @@ module Gapic
                         max_delay: @max_delay,
                         multiplier: @multiplier,
                         retry_codes: @retry_codes,
-                        timeout: @timeout
+                        timeout: @timeout,
+                        jitter: @jitter
       end
 
       ##
@@ -186,6 +201,7 @@ module Gapic
         @initial_delay ||= retry_policy[:initial_delay]
         @multiplier    ||= retry_policy[:multiplier]
         @max_delay     ||= retry_policy[:max_delay]
+        @jitter        = retry_policy.key?(:jitter) ? retry_policy[:jitter] : @jitter
 
         self
       end
@@ -197,30 +213,34 @@ module Gapic
           other.max_delay == max_delay &&
           other.multiplier == multiplier &&
           other.retry_codes == retry_codes &&
-          other.timeout == timeout
+          other.timeout == timeout &&
+          other.jitter == jitter
       end
       alias == eql?
 
       # @private Hash code
       def hash
-        [initial_delay, max_delay, multiplier, retry_codes, timeout].hash
+        [initial_delay, max_delay, multiplier, retry_codes, timeout, jitter].hash
       end
 
       private
 
       # @private
+      # Perform the currently calculated delay, adding a jitter.
+      #
       # @return [Numeric] The performed delay.
       def delay!
+        delay_to_perform = [delay + Kernel.rand(0.0..jitter), max_delay].min
         if @mock_time
-          @mock_time += delay
-          @mock_delay_callback&.call delay
+          @mock_time += delay_to_perform
+          @mock_delay_callback&.call delay_to_perform
         else
-          Kernel.sleep delay
+          Kernel.sleep delay_to_perform
         end
       end
 
       # @private
-      # @return [Numeric] The new delay in seconds.
+      # @return [Numeric] The new delay (sans jitter) in seconds.
       def increment_delay!
         @delay = [delay * multiplier, max_delay].min
       end

--- a/gapic-common/lib/gapic/common/retry_policy.rb
+++ b/gapic-common/lib/gapic/common/retry_policy.rb
@@ -201,7 +201,7 @@ module Gapic
         @initial_delay ||= retry_policy[:initial_delay]
         @multiplier    ||= retry_policy[:multiplier]
         @max_delay     ||= retry_policy[:max_delay]
-        @jitter        = retry_policy.key?(:jitter) ? retry_policy[:jitter] : @jitter
+        @jitter        ||= retry_policy[:jitter]
 
         self
       end

--- a/gapic-common/lib/gapic/operation/retry_policy.rb
+++ b/gapic-common/lib/gapic/operation/retry_policy.rb
@@ -38,13 +38,15 @@ module Gapic
       # @param multiplier [Numeric] The delay scaling factor for each subsequent retry attempt.
       # @param max_delay [Numeric] Maximum delay in seconds.
       # @param timeout [Numeric] Timeout threshold value in seconds.
+      # @param jitter [Numeric] Random jitter added to the delay in seconds.
       #
-      def initialize initial_delay: nil, multiplier: nil, max_delay: nil, timeout: nil
+      def initialize initial_delay: nil, multiplier: nil, max_delay: nil, timeout: nil, jitter: nil
         super(
           initial_delay: initial_delay || DEFAULT_INITIAL_DELAY,
           max_delay: max_delay || DEFAULT_MAX_DELAY,
           multiplier: multiplier || DEFAULT_MULTIPLIER,
-          timeout: timeout || DEFAULT_TIMEOUT
+          timeout: timeout || DEFAULT_TIMEOUT,
+          jitter: jitter
         )
       end
     end

--- a/gapic-common/test/gapic/call_options/retry_policy/call_test.rb
+++ b/gapic-common/test/gapic/call_options/retry_policy/call_test.rb
@@ -31,7 +31,8 @@ class RetryPolicyCallTest < Minitest::Test
 
   def test_retries_configured_grpc_errors
     retry_policy = Gapic::CallOptions::RetryPolicy.new(
-      retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE]
+      retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE],
+      jitter: 0
     )
     grpc_error = GRPC::Unavailable.new
 
@@ -50,7 +51,8 @@ class RetryPolicyCallTest < Minitest::Test
 
   def test_retries_configured_http_errors
     retry_policy = Gapic::CallOptions::RetryPolicy.new(
-      retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE]
+      retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE],
+      jitter: 0
     )
     faraday_error = OpenStruct.new response_status: 503
 
@@ -69,7 +71,8 @@ class RetryPolicyCallTest < Minitest::Test
 
   def test_retries_configured_http_errors_with_absent_status
     retry_policy = Gapic::CallOptions::RetryPolicy.new(
-      retry_codes: [GRPC::Core::StatusCodes::UNKNOWN]
+      retry_codes: [GRPC::Core::StatusCodes::UNKNOWN],
+      jitter: 0
     )
     faraday_error = OpenStruct.new response_status: nil
 
@@ -88,7 +91,8 @@ class RetryPolicyCallTest < Minitest::Test
 
   def test_wont_retry_unconfigured_grpc_errors
     retry_policy = Gapic::CallOptions::RetryPolicy.new(
-      retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE]
+      retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE],
+      jitter: 0
     )
     grpc_error = GRPC::Unimplemented.new
 
@@ -103,7 +107,8 @@ class RetryPolicyCallTest < Minitest::Test
 
   def test_wont_retry_non_grpc_errors
     retry_policy = Gapic::CallOptions::RetryPolicy.new(
-      retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE]
+      retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE],
+      jitter: 0
     )
     other_error = StandardError.new
 
@@ -116,7 +121,8 @@ class RetryPolicyCallTest < Minitest::Test
 
   def test_incremental_backoff
     retry_policy = Gapic::CallOptions::RetryPolicy.new(
-      retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE]
+      retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE],
+      jitter: 0
     )
     grpc_error = GRPC::Unavailable.new
 

--- a/gapic-common/test/gapic/common/retry_policy_test.rb
+++ b/gapic-common/test/gapic/common/retry_policy_test.rb
@@ -21,17 +21,18 @@ class RetryPolicyTest < Minitest::Test
   def test_init_with_values
     retry_policy = Gapic::Common::RetryPolicy.new(
       initial_delay: 2, max_delay: 20, multiplier: 1.7,
-      retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE], timeout: 600
+      retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE], timeout: 600, jitter: 0
     )
     assert_equal 2, retry_policy.initial_delay
     assert_equal 20, retry_policy.max_delay
     assert_equal 1.7, retry_policy.multiplier
     assert_equal [GRPC::Core::StatusCodes::UNAVAILABLE], retry_policy.retry_codes
     assert_equal 600, retry_policy.timeout
+    assert_equal 0, retry_policy.jitter
   end
 
   def test_perform_delay_increment_delay
-    retry_policy = Gapic::Common::RetryPolicy.new initial_delay: 1, max_delay: 5, multiplier: 1.3
+    retry_policy = Gapic::Common::RetryPolicy.new initial_delay: 1, max_delay: 5, multiplier: 1.3, jitter: 0
     retry_policy.start! mock_delay: true
     retry_policy.perform_delay!
     refute_equal retry_policy.initial_delay, retry_policy.delay
@@ -39,7 +40,7 @@ class RetryPolicyTest < Minitest::Test
   end
 
   def test_perform_delay_retry_common_logic
-    retry_policy = Gapic::Common::RetryPolicy.new initial_delay: 3, max_delay: 10, multiplier: 2
+    retry_policy = Gapic::Common::RetryPolicy.new initial_delay: 3, max_delay: 10, multiplier: 2, jitter: 0
     retry_policy.define_singleton_method :retry? do
       true
     end
@@ -49,7 +50,7 @@ class RetryPolicyTest < Minitest::Test
   end
 
   def test_perform_delay_retry_error_logic
-    retry_policy = Gapic::Common::RetryPolicy.new initial_delay: 5, max_delay: 30, multiplier: 3
+    retry_policy = Gapic::Common::RetryPolicy.new initial_delay: 5, max_delay: 30, multiplier: 3, jitter: 0
     retry_policy.define_singleton_method :retry_error? do |_error|
       true
     end
@@ -59,16 +60,59 @@ class RetryPolicyTest < Minitest::Test
   end
 
   def test_max_delay_limit
-    retry_policy = Gapic::Common::RetryPolicy.new initial_delay: 10, max_delay: 12, multiplier: 1.5
+    retry_policy = Gapic::Common::RetryPolicy.new initial_delay: 10, max_delay: 12, multiplier: 1.5, jitter: 0
     retry_policy.start! mock_delay: true
     retry_policy.perform_delay!
     assert_equal 12, retry_policy.delay
   end
 
   def test_retry_policy_deadline_init
-    Process.stub :clock_gettime, 123456789.0 do
-      retry_policy = Gapic::Common::RetryPolicy.new timeout: 10
-      assert_equal 123456799.0, retry_policy.send(:deadline)
+    Process.stub :clock_gettime, 123_456_789.0 do
+      retry_policy = Gapic::Common::RetryPolicy.new timeout: 10, jitter: 0
+      assert_equal 123_456_799.0, retry_policy.send(:deadline)
     end
+  end
+
+  def test_negative_jitter_raises_error
+    assert_raises ArgumentError do
+      Gapic::Common::RetryPolicy.new jitter: -1.0
+    end
+  end
+
+  def test_jitter_is_added
+    retry_policy = Gapic::Common::RetryPolicy.new initial_delay: 5, max_delay: 10, multiplier: 2, jitter: 2.0
+
+    delays_performed = []
+    retry_policy.start! mock_delay: ->(d) { delays_performed << d }
+
+    Kernel.stub :rand, 1.5 do
+      retry_policy.perform_delay!
+    end
+
+    # base delay = 5, rand = 1.5, actual = 6.5
+    assert_equal 6.5, delays_performed.first
+    # internal state should remain deterministic
+    assert_equal 10, retry_policy.delay
+  end
+
+  def test_jitter_bounds
+    retry_policy = Gapic::Common::RetryPolicy.new initial_delay: 5, max_delay: 6, multiplier: 2, jitter: 2.0
+
+    delays_performed = []
+    retry_policy.start! mock_delay: ->(d) { delays_performed << d }
+
+    Kernel.stub :rand, 2.0 do
+      retry_policy.perform_delay!
+    end
+
+    # base delay is 5, rand is 2.0 = 7.0, capped at max_delay of 6
+    assert_equal 6, delays_performed.first
+
+    Kernel.stub :rand, 2.0 do
+      retry_policy.perform_delay!
+    end
+
+    # internal state is now 10, rand is 2.0 = 12.0, capped at max_delay of 6
+    assert_equal 6, delays_performed.last
   end
 end

--- a/gapic-common/test/gapic/generic_lro_test.rb
+++ b/gapic-common/test/gapic/generic_lro_test.rb
@@ -317,7 +317,7 @@ class GenericLROTest < Minitest::Test
       assert_equal expected_delays.shift, delay
     end
     retry_policy = Gapic::Operation::RetryPolicy.new initial_delay: 10, multiplier: 2,
-                                                      max_delay: (5 * 60), timeout: (60 * 60)
+                                                      max_delay: (5 * 60), timeout: (60 * 60), jitter: 0
     retry_policy.start! mock_delay: delays_tester
     op.wait_until_done! retry_policy: retry_policy
     assert op.done?

--- a/gapic-common/test/gapic/grpc/rpc_call/retry/raise_test.rb
+++ b/gapic-common/test/gapic/grpc/rpc_call/retry/raise_test.rb
@@ -39,7 +39,7 @@ class RpcCallRetryRaiseTest < Minitest::Test
     rpc_call = Gapic::ServiceStub::RpcCall.new api_meth_stub
 
     options = Gapic::CallOptions.new(
-      retry_policy: { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+      retry_policy: { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE], jitter: 0 }
     )
     assert_raises GRPC::BadStatus do
       rpc_call.call Object.new, options: options
@@ -54,7 +54,7 @@ class RpcCallRetryRaiseTest < Minitest::Test
     rpc_call = Gapic::ServiceStub::RpcCall.new api_meth_stub
 
     options = Gapic::CallOptions.new(
-      retry_policy: { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+      retry_policy: { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE], jitter: 0 }
     )
     assert_raises FakeCodeError do
       rpc_call.call Object.new, options: options
@@ -88,7 +88,7 @@ class RpcCallRetryRaiseTest < Minitest::Test
 
     options = Gapic::CallOptions.new(
       timeout: 300,
-      retry_policy: { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+      retry_policy: { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE], jitter: 0 }
     )
 
     Kernel.stub :sleep, sleep_proc do
@@ -129,7 +129,7 @@ class RpcCallRetryRaiseTest < Minitest::Test
     sleep_proc = ->(count) { sleep_mock.sleep count }
 
     options = Gapic::CallOptions.new(
-      retry_policy: { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+      retry_policy: { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE], jitter: 0 }
     )
 
     Kernel.stub :sleep, sleep_proc do

--- a/gapic-common/test/gapic/grpc/rpc_call/retry/retry_test.rb
+++ b/gapic-common/test/gapic/grpc/rpc_call/retry/retry_test.rb
@@ -49,7 +49,7 @@ class RpcCallRetryTest < Minitest::Test
     rpc_call = Gapic::ServiceStub::RpcCall.new api_meth_stub
     options = Gapic::CallOptions.new(
       timeout: 300,
-      retry_policy: { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+      retry_policy: { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE], jitter: 0 }
     )
 
     sleep_mock = Minitest::Mock.new

--- a/gapic-common/test/gapic/operation_test.rb
+++ b/gapic-common/test/gapic/operation_test.rb
@@ -395,7 +395,7 @@ describe Gapic::Operation do
         _(delay).must_equal expected_delays.shift
       end
       retry_policy = Gapic::Operation::RetryPolicy.new initial_delay: 10, multiplier: 2,
-                                                       max_delay: (5 * 60), timeout: (60 * 60)
+                                                       max_delay: (5 * 60), timeout: (60 * 60), jitter: 0
       retry_policy.start! mock_delay: delays_tester
       op.wait_until_done! retry_policy: retry_policy
       _(op).must_be :done?

--- a/gapic-common/test/gapic/rest/client_stub/retry/raise_test.rb
+++ b/gapic-common/test/gapic/rest/client_stub/retry/raise_test.rb
@@ -29,7 +29,7 @@ class ClientStubRetryRaiseTest < ClientStubTestBase
     end
 
     options = Gapic::CallOptions.new(
-      retry_policy: { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+      retry_policy: { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE], jitter: 0 }
     )
 
     client_stub.stub :base_make_http_request, make_request_proc do
@@ -78,7 +78,7 @@ class ClientStubRetryRaiseTest < ClientStubTestBase
     end
     
     options = Gapic::CallOptions.new(
-      retry_policy: { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+      retry_policy: { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE], jitter: 0 }
     )
 
     client_stub.stub :base_make_http_request, make_request_proc do
@@ -125,7 +125,7 @@ class ClientStubRetryRaiseTest < ClientStubTestBase
     options = Gapic::CallOptions.new(
       timeout: time_delay * to_attempt + 0.1, # `+0.1` means that timeout stays positive on last cycle  
       retry_policy: {
-        retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE], 
+        retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE], jitter: 0
       }
     )
 
@@ -173,10 +173,9 @@ class ClientStubRetryRaiseTest < ClientStubTestBase
 
     options = Gapic::CallOptions.new(
       retry_policy: {
-        retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE], 
+        retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE], jitter: 0
       }
     )
-
     Kernel.stub :sleep, sleep_proc do
       client_stub.stub :base_make_http_request, make_request_proc do
         ex = assert_raises ::Gapic::Rest::DeadlineExceededError do

--- a/gapic-common/test/gapic/rest/client_stub/retry/raise_test_legacy.rb
+++ b/gapic-common/test/gapic/rest/client_stub/retry/raise_test_legacy.rb
@@ -55,7 +55,7 @@ class ClientStubRetryRaiseLegacyTest < ClientStubTestBase
     end
     
     options = Gapic::CallOptions.new(
-      retry_policy: { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+      retry_policy: { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE], jitter: 0 }
     )
 
     client_stub.stub :base_make_http_request, make_request_proc do
@@ -91,10 +91,9 @@ class ClientStubRetryRaiseLegacyTest < ClientStubTestBase
 
     options = Gapic::CallOptions.new(
       retry_policy: {
-        retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE], 
+        retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE], jitter: 0
       }
     )
-
     Kernel.stub :sleep, sleep_proc do
       client_stub.stub :base_make_http_request, make_request_proc do
         ex = assert_raises Faraday::TimeoutError do

--- a/gapic-common/test/gapic/rest/client_stub/retry/retry_test.rb
+++ b/gapic-common/test/gapic/rest/client_stub/retry/retry_test.rb
@@ -57,7 +57,7 @@ class ClientStubRetryRetryTest < ClientStubTestBase
     options = Gapic::CallOptions.new(
       timeout: time_delay * to_attempt + 0.1, # `+0.1` means that timeout stays positive on last cycle  
       retry_policy: {
-        retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE], 
+        retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE], jitter: 0
       }
     )
 


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

Ads a small positive jitter to retry policies. Jitter prevents multiple clients from retrying all at the same time. Jitter is added as a random value from 0 to `jitter` seconds. Default value for `jitter` is 1.

closes: #53