### PR TITLE
chore: Ruby 3.2 minimum, 4.0 default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            ruby: "3.1"
-            task: "--test"
-          - os: ubuntu-latest
             ruby: "3.2"
             task: "--test"
           - os: ubuntu-latest
@@ -39,13 +36,16 @@ jobs:
             ruby: "3.4"
             task: "--test"
           - os: ubuntu-latest
-            ruby: "3.4"
+            ruby: "4.0"
+            task: "--test"
+          - os: ubuntu-latest
+            ruby: "4.0"
             task: "--rubocop --build --yard --linkinator"
           - os: macos-latest
-            ruby: "3.4"
+            ruby: "4.0"
             task: "--test"
           - os: windows-latest
-            ruby: "3.4"
+            ruby: "4.0"
             task: "--test"
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/gapic-common/.rubocop.yml
+++ b/gapic-common/.rubocop.yml
@@ -2,6 +2,7 @@ inherit_gem:
   google-style: google-style.yml
 
 AllCops:
+  TargetRubyVersion: 3.2
   Exclude:
     - "test/**/*"
 

--- a/gapic-common/Gemfile
+++ b/gapic-common/Gemfile
@@ -14,3 +14,5 @@ gem "minitest-rg", "~> 5.3"
 gem "pry", ">= 0.14"
 gem "redcarpet", "~> 3.0"
 gem "yard", "~> 0.9"
+
+gem "ostruct"

--- a/gapic-common/README.md
+++ b/gapic-common/README.md
@@ -15,7 +15,7 @@ convenient and idiomatic API surface to callers.
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 3.0+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or in

--- a/gapic-common/gapic-common.gemspec
+++ b/gapic-common/gapic-common.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.platform =      Gem::Platform::RUBY
 
-  spec.required_ruby_version = ">= 3.1"
+  spec.required_ruby_version = ">= 3.2"
 
   spec.add_dependency "faraday", ">= 1.9", "< 3.a"
   spec.add_dependency "faraday-retry", ">= 1.0", "< 3.a"

--- a/gapic/README.md
+++ b/gapic/README.md
@@ -5,11 +5,11 @@ Core namespace for Google generated API client tools.
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 3.0+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or in
-security maintenance, and not end of life. Currently, this means Ruby 3.0 and
+security maintenance, and not end of life. Currently, this means Ruby 3.2 and
 later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/gapic/gapic.gemspec
+++ b/gapic/gapic.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |spec|
                ["LICENSE"]
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 3.1"
+  spec.required_ruby_version = ">= 3.2"
 end

--- a/google-logging-utils/Gemfile
+++ b/google-logging-utils/Gemfile
@@ -9,3 +9,5 @@ gem "minitest-focus", "~> 1.4"
 gem "minitest-rg", "~> 5.3"
 gem "redcarpet", "~> 3.0"
 gem "yard", "~> 0.9"
+
+gem "logger"

--- a/google-logging-utils/README.md
+++ b/google-logging-utils/README.md
@@ -4,11 +4,11 @@ Utility classes for logging to Google Cloud Logging.
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 3.0+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or in
-security maintenance, and not end of life. Currently, this means Ruby 3.0 and
+security maintenance, and not end of life. Currently, this means Ruby 3.2 and
 later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-logging-utils/google-logging-utils.gemspec
+++ b/google-logging-utils/google-logging-utils.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |spec|
                ["LICENSE"]
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 3.1"
+  spec.required_ruby_version = ">= 3.2"
 end


### PR DESCRIPTION
refs: googleapis/google-auth-library-ruby#566